### PR TITLE
Парсер категории "Молотый кофе"

### DIFF
--- a/common/parser.py
+++ b/common/parser.py
@@ -5,7 +5,7 @@ import random
 
 class Helpers:
     @staticmethod
-    def randomDelay(min=2000, max=5000):
+    def randomDelay(min=4000, max=6000):
         i = random.randint(min, max)
         time.sleep(i / 1000)
 

--- a/main.py
+++ b/main.py
@@ -2,13 +2,13 @@ import marketplaces.beru
 
 if __name__ == '__main__':
     # Выполни adb devices в консоли, чтобы узнать идентификатор устройства
-    d = marketplaces.beru.Beru('UGPN9D5PA6NV49UO')
+    d = marketplaces.beru.Beru('R58R5306C6Z')
     d.open()
     d.clickCatalog()
-    d.catalog('Электроника')
-    d.catalog('Смартфоны и аксессуары')
-    d.catalog('Рации и прочие телефоны')
-    d.catalog('Проводные телефоны')
+    d.catalog('Продукты питания')
+    d.catalog('Чай, кофе, какао')
+    d.catalog('Кофе')
+    d.catalog('Молотый кофе')
 
     d.parseCatalog()
     d.close()

--- a/marketplaces/beru.py
+++ b/marketplaces/beru.py
@@ -1,9 +1,14 @@
 import common.parser as parser
 import unicodedata
+from datetime import date, datetime
+from uiautomator2.exceptions import UiObjectNotFoundError
+import json
 
 
 class Beru(parser.Parser):
     APP_CODE = "ru.beru.android"
+    DEFAULT_TIMEOUT = 5
+    PRODUCT_VIEW_XPATH = "//*[@resource-id='ru.beru.android:id/searchResultListView']//*[@resource-id='ru.beru.android:id/productOfferTitleView']"
 
     def open(self, **kwargs):
         super(Beru, self).close(self.APP_CODE)
@@ -12,6 +17,80 @@ class Beru(parser.Parser):
 
     def close(self, **kwargs):
         super(Beru, self).close(self.APP_CODE)
+
+    def _exit_product_view(self):
+        # ожидаем, что вью, который можно скроллить, прогрузился
+        self.d.press('back')
+        self.d(resourceId="ru.beru.android:id/searchResultListView").wait()
+
+    def _parse_product_view(self):
+        product = {'market': 'beru', 'rank': self.rank,
+                   'externalId': self.rank,
+                   'category': 'Молотый кофе',
+                   'observedAt': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+                   'oldPrice': None,
+                   'brand': None}
+
+        product_title = self.d(
+            resourceId="ru.beru.android:id/productSummaryTitleView")
+        product_price = self.d(
+            resourceId="ru.beru.android:id/pricesPriceView")
+        product_old_price = self.d(
+            resourceId="ru.beru.android:id/pricesBasePriceView")
+        product_brand = self.d(
+            resourceId="ru.beru.android:id/button", instance=0)
+
+        if product_title.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+            title = product_title.get_text()
+            product['title'] = product['sku'] = title
+        else:
+            product_title = self.d(resourceId="ru.beru.android:id/title")
+            if product_title.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+                title = product_title.get_text()
+                product['title'] = product['sku'] = title
+
+        if product_price.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+            price = product_price.get_text()
+            product['price'] = int(price.replace('\xa0', '').replace('₽', '') + '00')
+
+        if product_old_price.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+            old_price = product_old_price.get_text()
+            product['oldPrice'] = int(old_price.replace('\xa0', '').replace('₽', '') + '00')
+
+        if product_brand.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+            brand = product_brand.get_text()
+            if brand:
+                product['brand'] = brand
+
+        desc_rid = 'ru.beru.android:id/characteristicsAndDescriptionDescription'
+
+        # scroll view может быть не прогружен, а может и в принципе отсутствовать
+        # Одна из разновидностей вот такая:
+        # scroll_view = self.d(resourceId='ru.beru.android:id/viewPager')
+        scroll_view = self.d(scrollable=True)
+        if not scroll_view.wait(exists=True, timeout=2):
+            return product
+        
+        if not scroll_view.scroll.to(resourceId=desc_rid):
+            return product
+
+        product_description = self.d(resourceId=desc_rid, instance=0)
+        if not product_description.wait(exists=True, timeout=2):
+            return product
+
+        try:
+            product_description.click(timeout=2)
+        except UiObjectNotFoundError:
+            return product
+
+        # после обнволения запрос нужно выполнить заново
+        product_description = self.d(resourceId=desc_rid, instance=0)
+        if not product_description.wait(exists=True, timeout=self.DEFAULT_TIMEOUT):
+            return product
+        
+        product['description'] = product_description.get_text()
+        return product
+
 
     def catalog(self, catalog_name):
 
@@ -26,82 +105,86 @@ class Beru(parser.Parser):
 
         parser.Helpers.randomDelay()
 
+    def _restore_position(self):
+        if not self.already:
+            return
+        # Скролллим до момента, пока не появляется новый товар
+        results = self.d(resourceId="ru.beru.android:id/searchResultListView")
+
+        results.scroll.toBeginning(steps=10, max_swipes=99999)
+        results.wait(timeout=5.0)
+        for elem in self.d.xpath(self.PRODUCT_VIEW_XPATH).all():
+            if elem.text not in self.already:
+                return True
+    
+    def _parse_scroll_view(self):
+        results = self.d(resourceId="ru.beru.android:id/searchResultListView")
+        while True:
+            for elem in self.d.xpath(self.PRODUCT_VIEW_XPATH).all():
+                # Скролл не всегда гарантирует появление нового элемента
+                if elem.text in self.already:
+                    pass
+                else:
+                    self.already.add(elem.text)
+                    self.rank += 1
+                    elem.click()
+                    product = self._parse_product_view()
+                    self.ended = datetime.now()
+
+                    if product:
+                        self.items.append(product)
+                        print(json.dumps(product, ensure_ascii=False))
+
+                    self._exit_product_view()
+            while not self.results.scroll.forward():
+                parser.Helpers.randomDelay()
+    
     def parseCatalog(self):
+        """Точка входа в парсер."""
+        self.results = self.d(resourceId="ru.beru.android:id/searchResultListView")
+        self.results.scroll.toBeginning(steps=10, max_swipes=99999)
+        self.results.wait(timeout=5.0)
+        self.already = set()
+        self.items = []
+        self.rank = 0
+        self.started = datetime.now()
+
+        # TODO: тестируем то, что мы не успели что-либо сломать
+        self._parse_scroll_view()
+        
+
+    def parse_Catalog(self):
         # Дождемся пока результаты появятся
         results = self.d(resourceId="ru.beru.android:id/searchResultListView")
 
         results.scroll.toBeginning(steps=10, max_swipes=99999)
         results.wait(timeout=5.0)
 
-        already = []
-        data = []
+        self.already = set()
+        self.items = []
 
-        scrolling = True
-        scrolling_start = False
+        self.rank = 0
+        self.started = datetime.now()
 
-        while scrolling:
-            if scrolling_start:
-                print("Scrolling forward")
-                make_scroll = results.scroll.forward()
-
-                # Если скроллить ниже не получается - делаем еще одну попытку
-                # Дело в том, что новые элементы списка могли не успеть подгрузиться по сети
-                if make_scroll:
-                    print("Scrolling okay")
-                    scrolling = make_scroll
-                else:
-                    print("Scrolling forward failed, trying one more time in 2 seconds")
-                    parser.Helpers.randomDelay()
-                    scrolling = results.scroll.forward()
-
-            scrolling_start = True
-
-            for elem in self.d.xpath(
-                    "//*[@resource-id='ru.beru.android:id/searchResultListView']//*[@resource-id='ru.beru.android:id/productOfferTitleView']").all():
-
-                if elem.text in already:
+        while True:
+            for elem in self.d.xpath(self.PRODUCT_VIEW_XPATH).all():
+                # Скролл не всегда гарантирует появление нового элемента
+                if elem.text in self.already:
                     pass
-                    print("Name " + elem.text + " duplicated! Skipping...")
                 else:
-                    print("Found name with data // " + elem.text)
-                    already.append(elem.text)
-
+                    self.already.add(elem.text)
+                    self.rank += 1
                     elem.click()
+                    product = self._parse_product_view()
+                    self.ended = datetime.now()
 
-                    product = {}
+                    if product:
+                        self.items.append(product)
+                        print(json.dumps(product, ensure_ascii=False))
 
-                    product_title = self.d(resourceId="ru.beru.android:id/productSummaryTitleView")
-                    product_price = self.d(resourceId="ru.beru.android:id/actualPriceView")
-                    product_old_price = self.d(resourceId="ru.beru.android:id/basePriceView")
-                    product_brand = self.d(resourceId="ru.beru.android:id/button", instance=0)
-                    product_reviews = self.d(resourceId="ru.beru.android:id/ratingBriefView", instance=0)
-
-                    if product_title.exists:
-                        product_title.wait()
-                        product['title'] = product_title.get_text()
-
-                    if product_price.exists:
-                        price = product_price.get_text()
-                        product['price'] = unicodedata.normalize("NFKD", price)
-
-                    if product_old_price.exists:
-                        old_price = product_old_price.get_text()
-                        product['old_price'] = unicodedata.normalize("NFKD", old_price)
-
-                    if product_brand.exists:
-                        product['brand'] = product_brand.get_text()
-
-                    if product_reviews.exists:
-                        product['reviews'] = product_reviews.get_text()
-
-                    data.append(product)
-
-                    print(product)
-
-                    self.d.press('back')
-                    self.d(resourceId="ru.beru.android:id/searchResultListView").wait()
-
-        print(data)
+                    self._exit_product_view()
+            while not results.scroll.forward():
+                parser.Helpers.randomDelay()
 
     def clickCatalog(self, and_wait=True):
         self.d(resourceId="ru.beru.android:id/nav_catalog", instance=0).click()


### PR DESCRIPTION
Важно: в коде ниже зависание/бан обрабатывается, но не отлавливается ([пример 1](https://github.com/kolyadin/android-parser/compare/master...gv-dentsu:coffee-task?expand=1#diff-31c87e8b84b7fdc0472007fa59c7a3032df2b9a021f9559195b5c8eb69b1f28eR111), [пример 2](https://github.com/kolyadin/android-parser/compare/master...gv-dentsu:coffee-task?expand=1#diff-31c87e8b84b7fdc0472007fa59c7a3032df2b9a021f9559195b5c8eb69b1f28eR66)). Это позволяло мне сохранять некоторую гибкость при сборе данных: в случае ошибки можно восстановить последнее положение парсера в результатах поиска, дампнуть view в stdout для дальнейшего анализа etc.

Я запускал код при помощи `python -i main.py` и после падения / прерывания сохранял результат при помощи `d._save_result()` (либо восстанавливал работу автоматизатора и запускал дальше). Если такой способ неудобен для того, чтобы с ним дальше работать -- могу добавить в ветку коммит, который будет делать `d._save_result()` в случае *любой* критической ошибки.

P.S. На всякий случай добавляю сюда пример того, что я называю баном:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/86488237/123461639-0190c980-d5f2-11eb-9131-121edf5eb497.png)

